### PR TITLE
Added post creation timestamp.

### DIFF
--- a/routes/publicacion.js
+++ b/routes/publicacion.js
@@ -36,12 +36,16 @@ const add = async (firestore, req, res) => {
     });
   }
 
+  const today_date = new Date();
+  const creation_timestamp = today_date.getFullYear()+'-'+(today_date.getMonth()+1)+'-'+today_date.getDate();
+
   try {
     const collectionref = await firestore.collection('publicacion');
     const docref = await collectionref.add({
       post_author,
       post_text,
       post_files,
+      creation_timestamp
     }); // add new publicacion to publicacion collection
 
     res.send({


### PR DESCRIPTION
-Now posts are saved with their creation timestamp.

## What does this PR do?

1. Added creation timestamp to posts.
2. Now posts can be saved and added with their corresponding timestamp.

## Related issues this PR closes or is related to

Closes none.
